### PR TITLE
fix: recognize v2raytun user agents

### DIFF
--- a/shared/analyzers/user_agent.py
+++ b/shared/analyzers/user_agent.py
@@ -37,7 +37,7 @@ class UserAgentAnalyzer:
         r"^Happ/", r"^Stash/", r"^Streisand/", r"^V2Box/", r"^Karing/",
         r"^ShadowRocket/", r"^FoXray/", r"^Loon/", r"^Wings\s?X/",
         # Android
-        r"^v2rayNG/", r"^NekoBox/", r"^Exclave/", r"^Matsuri/", r"^SagerNet/",
+        r"^v2rayNG/", r"^v2raytun/", r"^NekoBox/", r"^Exclave/", r"^Matsuri/", r"^SagerNet/",
         r"^Hiddify/", r"^HiddifyNext/",
         # Clash/Mihomo family (cross-platform)
         r"^FlClash(?:\s?X)?/", r"^ClashX(?:\s?Pro)?/",

--- a/web/frontend/src/utils/userAgentClassifier.ts
+++ b/web/frontend/src/utils/userAgentClassifier.ts
@@ -3,7 +3,7 @@ export type UserAgentClass = 'valid' | 'link_in_ua' | 'bot_library' | 'stub' | '
 const WHITELIST = [
   /^Happ\//i, /^Stash\//i, /^Streisand\//i, /^V2Box\//i, /^Karing\//i,
   /^ShadowRocket\//i, /^FoXray\//i, /^Loon\//i, /^Wings\s?X\//i,
-  /^v2rayNG\//i, /^NekoBox\//i, /^Exclave\//i, /^Matsuri\//i, /^SagerNet\//i,
+  /^v2rayNG\//i, /^v2raytun\//i, /^NekoBox\//i, /^Exclave\//i, /^Matsuri\//i, /^SagerNet\//i,
   /^Hiddify\//i, /^HiddifyNext\//i,
   /^FlClash(?:\s?X)?\//i, /^ClashX(?:\s?Pro)?\//i,
   /^Clash(?:\s?Verge)?(?:\s?Rev)?\//i, /^ClashMeta\//i,


### PR DESCRIPTION
Fixes #253

This PR adds `v2raytun` User-Agent recognition to both frontend and backend classifiers.

Without this change, v2RayTun clients are displayed as "Unknown client" in the Devices section and may be classified as unknown by the backend analyzer.

Example User-Agents:

* `v2raytun/android`
* `v2raytun/windows`
