### PR TITLE
fix(backend): SQL builder misuse and nullable role in admin auth

### DIFF
--- a/shared/db/network.py
+++ b/shared/db/network.py
@@ -461,7 +461,7 @@ class NetworkMixin:
                     update_sql(
                         ASN_RUSSIA_TABLE,
                         "last_synced_at = NOW()",
-                        "WHERE is_active = true AND (last_synced_at IS NULL OR last_synced_at < NOW() - INTERVAL '1 hour')",
+                        "is_active = true AND (last_synced_at IS NULL OR last_synced_at < NOW() - INTERVAL '1 hour')",
                     ),
                 )
             
@@ -1639,7 +1639,7 @@ class NetworkMixin:
                         update_sql(
                             ACCESS_POLICIES_TABLE,
                             "name = COALESCE($2, name), description = COALESCE($3, description), updated_at = NOW()",
-                            "WHERE id = $1",
+                            "id = $1",
                         ),
                         policy_id, name, description,
                     )

--- a/web/backend/api/deps.py
+++ b/web/backend/api/deps.py
@@ -73,7 +73,7 @@ async def _resolve_password_admin(username: str, settings) -> AdminUser:
             return AdminUser(
                 telegram_id=account.get("telegram_id"),
                 username=account["username"],
-                role=account.get("role_name", "admin"),
+                role=account.get("role_name") or "admin",
                 role_id=account.get("role_id"),
                 auth_method="password",
                 account_id=account["id"],
@@ -130,7 +130,7 @@ async def _resolve_telegram_admin(subject: str, payload: dict, settings) -> Admi
             return AdminUser(
                 telegram_id=telegram_id,
                 username=account["username"],
-                role=account.get("role_name", "admin"),
+                role=account.get("role_name") or "admin",
                 role_id=account.get("role_id"),
                 auth_method="telegram",
                 account_id=account["id"],

--- a/web/backend/api/v2/notifications.py
+++ b/web/backend/api/v2/notifications.py
@@ -466,7 +466,11 @@ async def update_smtp_config(
             )
 
         row = await conn.fetchrow(
-            update_sql(SMTP_CONFIG_TABLE, ", ".join(updates), "WHERE id = (SELECT id FROM smtp_config ORDER BY id LIMIT 1) RETURNING *"),
+            update_sql(
+                SMTP_CONFIG_TABLE, ", ".join(updates),
+                "id = (SELECT id FROM smtp_config ORDER BY id LIMIT 1)",
+                returning="*",
+            ),
             *params,
         )
 
@@ -849,7 +853,7 @@ async def acknowledge_alerts(
     async with db_service.acquire() as conn:
         if data.ids:
             await conn.execute(
-                update_sql(ALERT_RULE_LOG_TABLE, "acknowledged = true, acknowledged_by = $1, acknowledged_at = NOW()", "WHERE id = ANY($2::bigint[])"),
+                update_sql(ALERT_RULE_LOG_TABLE, "acknowledged = true, acknowledged_by = $1, acknowledged_at = NOW()", "id = ANY($2::bigint[])"),
                 aid, data.ids,
             )
         else:


### PR DESCRIPTION
#### 1. Duplicate WHERE clause in `update_sql()`
`update_sql()` already prepends `WHERE` to its condition argument. Several
callers were passing strings starting with `"WHERE ..."`, producing invalid
SQL like `... WHERE WHERE id = $1`. Removed the redundant `WHERE` keyword
from:

- `shared/db/network.py` — `ASN_RUSSIA_TABLE` and `ACCESS_POLICIES_TABLE` updates
- `web/backend/api/v2/notifications.py` — `SMTP_CONFIG_TABLE` and `ALERT_RULE_LOG_TABLE` updates

The `update_sql(...)` call for SMTP config was also missing the explicit
`returning="*"` kwarg; now passed explicitly for consistency with other
call sites.

#### 2. Default role fallback when `role_name` is `NULL`
`AdminUser.role` is typed as `str` and `AdminInfo.role` is required, but
when an admin account had no role assigned the SQL LEFT JOIN returned
`role_name=NULL`. The previous code used `account.get("role_name", "admin")`,
which only falls back when the key is **absent** — a present-but-`None` value
slipped through and later raised `ValidationError: role Input should be a
valid string` on the `/api/v2/auth/me` endpoint.

Changed both resolver call sites in `web/backend/api/deps.py`
(`_resolve_password_admin` and `_resolve_telegram_admin`) to use
`account.get("role_name") or "admin"` so that `None` also falls back to
`"admin"`.