### PR TITLE
fix(security): trust proxy headers only from configured reverse proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,6 +238,23 @@ TELEGRAM_BOT_USERNAME=your_bot_username
 
 #WEB_ALLOWED_IPS=1.2.3.4,10.0.0.0/24
 
+# Доверенные reverse-proxy (через запятую, CIDR) / Trusted reverse proxies
+#
+# X-Real-IP / X-Forwarded-For принимаются ТОЛЬКО если запрос пришёл с этих
+# адресов; иначе берётся реальный адрес сокета. Это не даёт подделать свой IP
+# при прямом обращении к порту бэкенда (он же публичный порт коллектора) и
+# обойти WEB_ALLOWED_IPS, блокировку перебора и fail2ban.
+# X-Real-IP / X-Forwarded-For are honored ONLY from these addresses; otherwise
+# the raw socket address is used. Prevents IP spoofing when the backend port is
+# reached directly, bypassing WEB_ALLOWED_IPS, the login lockout and fail2ban.
+#
+# Пусто = доверять приватным/loopback диапазонам (как nginx set_real_ip_from).
+# РЕКОМЕНДАЦИЯ для прода: укажите ТОЧНЫЙ адрес вашего прокси/фронтенда, чтобы
+# исключить и docker-gateway (например адрес контейнера web-frontend).
+# Empty = trust private/loopback ranges. For production pin this to your proxy's
+# exact address so the docker gateway is excluded too.
+#WEB_TRUSTED_PROXIES=172.18.0.0/16
+
 # Секретный URL-путь (опционально)
 # Secret URL path (optional)
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,10 @@ services:
       WEB_PORT: '${WEB_BACKEND_PORT:-8081}'
       APP_MODE: '${APP_MODE:-full}'
       REDIS_URL: '${REDIS_URL:-}'
+      # Trust X-Real-IP/X-Forwarded-For only from the reverse proxy. The admin
+      # API shares the published collector port, so pin this to the frontend
+      # proxy's address to stop direct-port IP spoofing (see .env.example).
+      WEB_TRUSTED_PROXIES: '${WEB_TRUSTED_PROXIES:-}'
       MAXMIND_CITY_DB: /app/geoip/GeoLite2-City.mmdb
       MAXMIND_ASN_DB: /app/geoip/GeoLite2-ASN.mmdb
       BACKUP_DIR: /app/backups
@@ -145,6 +149,7 @@ services:
       WEB_PORT: '8081'
       APP_MODE: 'collector'
       REDIS_URL: '${REDIS_URL:-}'
+      WEB_TRUSTED_PROXIES: '${WEB_TRUSTED_PROXIES:-}'
       WEBHOOK_SECRET: '${WEBHOOK_SECRET:-}'
       BOT_WEBHOOK_URL: 'http://bot:${WEBHOOK_PORT:-8080}/webhook'
       BOT_CALLBACK_URL: 'http://bot:${WEBHOOK_PORT:-8080}/internal/panel-event'

--- a/web/backend/api/deps.py
+++ b/web/backend/api/deps.py
@@ -1,5 +1,6 @@
 """API dependencies for web panel."""
 import functools
+import ipaddress
 import logging
 from dataclasses import dataclass, field
 from typing import Optional, List, Tuple, Set
@@ -470,21 +471,79 @@ def require_quota(resource: str):
 
 # ── Utility helpers ─────────────────────────────────────────────
 
-def get_client_ip(request: Request) -> str:
-    """Extract client IP from trusted proxy headers.
+# Forwarding headers are honored only from these proxy ranges when
+# WEB_TRUSTED_PROXIES is not explicitly configured. Mirrors the bundled nginx
+# `set_real_ip_from` (loopback + RFC1918 + IPv6 ULA/link-local).
+_DEFAULT_TRUSTED_PROXY_CIDRS = (
+    "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+    "::1/128", "fc00::/7", "fe80::/10",
+)
 
-    Priority:
-    1. X-Real-IP (set by nginx, most reliable)
-    2. X-Forwarded-For first entry (set by upstream reverse proxy)
-    3. request.client.host (direct connection fallback)
+
+@functools.lru_cache(maxsize=1)
+def _trusted_proxy_networks() -> tuple:
+    """Parse WEB_TRUSTED_PROXIES into networks (cached). Empty → private ranges."""
+    raw = (get_web_settings().trusted_proxies_raw or "").strip()
+    entries = (
+        [e.strip() for e in raw.split(",") if e.strip()]
+        if raw else list(_DEFAULT_TRUSTED_PROXY_CIDRS)
+    )
+    nets = []
+    for entry in entries:
+        try:
+            nets.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            logger.warning("Invalid WEB_TRUSTED_PROXIES entry ignored: %s", entry)
+    return tuple(nets)
+
+
+def _parse_ip(value: str):
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _is_trusted_proxy(value: str) -> bool:
+    addr = _parse_ip(value)
+    if addr is None:
+        return False
+    return any(addr in net for net in _trusted_proxy_networks())
+
+
+def get_client_ip(request: Request) -> str:
+    """Resolve the real client IP, trusting proxy headers only from trusted proxies.
+
+    X-Real-IP / X-Forwarded-For are attacker-controllable, so they are honored
+    ONLY when the immediate peer (``request.client.host``) is a configured
+    trusted reverse proxy (``WEB_TRUSTED_PROXIES``). When the connection comes
+    straight to the backend port (e.g. the published collector port) the raw
+    socket address is used instead — a client cannot spoof its IP to bypass the
+    IP whitelist, the brute-force lockout, or fail2ban.
+
+    When the peer is trusted, priority is:
+    1. X-Real-IP — the bundled nginx overwrites it with the verified client IP.
+    2. right-most untrusted hop of X-Forwarded-For (skips our own proxies).
+    3. the peer address itself.
     """
-    real_ip = request.headers.get("x-real-ip")
-    if real_ip:
-        return real_ip.strip()
+    peer = request.client.host if request.client else ""
+
+    # Untrusted / direct connection — never trust forwarding headers.
+    if not peer or not _is_trusted_proxy(peer):
+        return peer or "unknown"
+
+    real_ip = request.headers.get("x-real-ip", "").strip()
+    if real_ip and _parse_ip(real_ip) is not None:
+        return real_ip
+
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+        for hop in reversed([h.strip() for h in forwarded.split(",") if h.strip()]):
+            if _parse_ip(hop) is None or _is_trusted_proxy(hop):
+                continue
+            return hop
+
+    return peer
 
 
 async def get_db():

--- a/web/backend/core/config.py
+++ b/web/backend/core/config.py
@@ -35,6 +35,14 @@ class WebSettings(BaseSettings):
     # IP whitelist (optional, comma-separated IPs/CIDRs — empty = allow all)
     allowed_ips: str = Field(default="", alias="WEB_ALLOWED_IPS")
 
+    # Trusted reverse-proxy addresses (comma-separated IPs/CIDRs).
+    # Forwarding headers (X-Real-IP / X-Forwarded-For) are honored ONLY when the
+    # direct peer is in this set — otherwise the raw socket address is used, so a
+    # client reaching the backend port directly cannot spoof its IP. Empty falls
+    # back to the standard private/loopback ranges (see deps.get_client_ip),
+    # which matches the bundled nginx `set_real_ip_from`.
+    trusted_proxies_raw: str = Field(default="", alias="WEB_TRUSTED_PROXIES")
+
     # CORS
     cors_origins_raw: str = Field(
         default="http://localhost:3000,http://localhost:5173",

--- a/web/backend/tests/test_get_client_ip.py
+++ b/web/backend/tests/test_get_client_ip.py
@@ -1,0 +1,96 @@
+"""Tests for deps.get_client_ip — trusted-proxy gated client IP resolution.
+
+The forwarding headers (X-Real-IP / X-Forwarded-For) are attacker-controllable,
+so they must be honored only when the immediate peer is a trusted reverse proxy.
+A client hitting the backend port directly must not be able to spoof its IP.
+"""
+import pytest
+
+from web.backend.core.config import get_web_settings
+from web.backend.api import deps
+from web.backend.api.deps import get_client_ip
+
+
+class _FakeClient:
+    def __init__(self, host):
+        self.host = host
+
+
+class FakeRequest:
+    def __init__(self, peer="203.0.113.7", headers=None):
+        self.client = _FakeClient(peer) if peer is not None else None
+        self.headers = {k.lower(): v for k, v in (headers or {}).items()}
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch):
+    """Each test sets WEB_TRUSTED_PROXIES fresh; clear the two relevant caches."""
+    def _set(value):
+        monkeypatch.setenv("WEB_TRUSTED_PROXIES", value)
+        get_web_settings.cache_clear()
+        deps._trusted_proxy_networks.cache_clear()
+    yield _set
+    get_web_settings.cache_clear()
+    deps._trusted_proxy_networks.cache_clear()
+
+
+# ── Untrusted / direct connection: headers must be ignored ──────────────
+
+def test_direct_public_peer_ignores_spoofed_real_ip(_reset_caches):
+    _reset_caches("10.0.0.0/8")  # public peer is NOT trusted
+    req = FakeRequest(peer="203.0.113.9", headers={"X-Real-IP": "10.0.0.5"})
+    assert get_client_ip(req) == "203.0.113.9"
+
+
+def test_direct_public_peer_ignores_spoofed_forwarded_for(_reset_caches):
+    _reset_caches("10.0.0.0/8")
+    req = FakeRequest(
+        peer="203.0.113.9",
+        headers={"X-Forwarded-For": "1.1.1.1, 10.0.0.5"},
+    )
+    assert get_client_ip(req) == "203.0.113.9"
+
+
+def test_missing_client_returns_unknown(_reset_caches):
+    _reset_caches("")
+    req = FakeRequest(peer=None)
+    assert get_client_ip(req) == "unknown"
+
+
+# ── Trusted proxy: real client IP is taken from headers ─────────────────
+
+def test_trusted_proxy_uses_x_real_ip(_reset_caches):
+    _reset_caches("172.18.0.0/16")
+    req = FakeRequest(peer="172.18.0.5", headers={"X-Real-IP": "203.0.113.50"})
+    assert get_client_ip(req) == "203.0.113.50"
+
+
+def test_trusted_proxy_xff_rightmost_untrusted(_reset_caches):
+    _reset_caches("172.18.0.0/16")
+    # Client -> edge(8.8.8.8) -> our proxy(172.18.0.5). Rightmost untrusted is the
+    # real client edge, not a left-most value a client could inject.
+    req = FakeRequest(
+        peer="172.18.0.5",
+        headers={"X-Forwarded-For": "evil-spoof, 203.0.113.50, 172.18.0.9"},
+    )
+    assert get_client_ip(req) == "203.0.113.50"
+
+
+def test_trusted_proxy_invalid_real_ip_falls_back_to_peer(_reset_caches):
+    _reset_caches("172.18.0.0/16")
+    req = FakeRequest(peer="172.18.0.5", headers={"X-Real-IP": "not-an-ip"})
+    assert get_client_ip(req) == "172.18.0.5"
+
+
+# ── Default (empty) trusts private ranges, matching nginx ───────────────
+
+def test_default_trusts_private_peer(_reset_caches):
+    _reset_caches("")
+    req = FakeRequest(peer="172.18.0.5", headers={"X-Real-IP": "203.0.113.50"})
+    assert get_client_ip(req) == "203.0.113.50"
+
+
+def test_default_ignores_headers_from_public_peer(_reset_caches):
+    _reset_caches("")
+    req = FakeRequest(peer="198.51.100.10", headers={"X-Real-IP": "10.0.0.1"})
+    assert get_client_ip(req) == "198.51.100.10"


### PR DESCRIPTION
get_client_ip() honored X-Real-IP / X-Forwarded-For from any source, while the backend admin API shares the publicly published collector port. A client reaching that port directly could spoof its IP via these headers and bypass the WEB_ALLOWED_IPS whitelist, the per-IP brute-force lockout, and fail2ban.

Forwarding headers are now honored only when the immediate peer (request.client.host) is in the new WEB_TRUSTED_PROXIES allowlist; otherwise the raw socket address is used. X-Forwarded-For is parsed right-to-left, skipping trusted hops, instead of trusting the (client-controlled) first entry.

- deps.py: trusted-proxy gate + rightmost-untrusted XFF parsing + IP validation
- config.py: new WEB_TRUSTED_PROXIES setting (empty = private/loopback ranges, matching nginx set_real_ip_from — no regression for the bundled deployment)
- docker-compose.yml: surface WEB_TRUSTED_PROXIES on backend and collector
- .env.example: document the setting; recommend pinning the exact proxy address in production so the docker gateway is excluded too
- tests: cover spoofing rejection and the legitimate proxied path