### PR TITLE
fix(plugins): sync superadmin permissions after plugins are loaded

### DIFF
--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -695,6 +695,18 @@ async def lifespan(app: FastAPI):
                     except Exception:
                         logger.exception("Plugin loader failed during startup")
 
+                    # Plugin RBAC resources only exist after register() ran, so the
+                    # earlier sync could not see them: a freshly installed plugin
+                    # never got its permission on the superadmin role, and the
+                    # sidebar hides nav entries whose permission is missing.
+                    # The call is idempotent — it only inserts what is absent.
+                    try:
+                        from web.backend.core.rbac import sync_superadmin_permissions
+
+                        await sync_superadmin_permissions()
+                    except Exception:
+                        logger.exception("Superadmin permission sync after plugin load failed")
+
                     try:
                         plugin_tasks = plugin_loader.start_scheduled_tasks()
                         if plugin_tasks:


### PR DESCRIPTION
Closes #268

### Проблема

`sync_superadmin_permissions()` вызывается при подключении к БД, то есть **до** загрузки плагинов:

- `web/backend/main.py:542` — `await sync_superadmin_permissions()`
- `web/backend/main.py:694` — `plugin_loader.register(app)`

Функция берёт список ресурсов из `get_resources_map()`, а тот складывает встроенные ресурсы с `get_extra_rbac_resources()`. Последние заполняются только внутри `plugins.register()`, поэтому на момент синхронизации словарь ещё пуст. При следующем старте порядок тот же, так что состояние не «догоняет» само.

Снаружи это выглядит как «плагин установился, но его нигде нет»: `NavEntry` фильтруется по праву, и пункт меню не рисуется вообще — даже суперадмину, хотя `/api/v2/plugins` плагин отдаёт вместе с его `navigation`. Право можно выдать вручную в разделе ролей (там карта ресурсов строится во время запроса, поэтому ресурс плагина в списке есть), из-за чего причина легко проходит мимо внимания.

### Решение

Вызвать ту же функцию ещё раз сразу после `register(app)`. Она идемпотентна: сравнивает полный набор с уже выданными и вставляет только недостающее, так что при отсутствии новых ресурсов это один SELECT. Ранний вызов оставлен на месте — он по-прежнему подхватывает изменения встроенных ресурсов до того, как поднимутся остальные сервисы.

Импорт сделан локально в этом же блоке: раннее связывание имени зависит от ветки `if connected`, а падение синхронизации не должно ронять старт — поэтому вызов обёрнут в `try/except` с логированием, как и соседние шаги.

### Проверка

Воспроизведено и проверено на 4.4.0 с плагином, объявляющим `rbac_resources={"<res>": ["view"]}` и `NavEntry(permission=("<res>","view"))`: до правки `<res>:view` в `GET /api/v2/auth/me` у суперадмина отсутствовал и пункт меню не отображался; после вызова синхронизации по факту регистрации в логе появляется `sync_superadmin_permissions: added N missing permissions: …`, право выдаётся и пункт меню рисуется.
