### PR TITLE
fix: empty verifyPeerCertByName string broke the hosts list (500)

### DIFF
--- a/web/backend/schemas/host.py
+++ b/web/backend/schemas/host.py
@@ -73,10 +73,13 @@ class HostListItem(HostBase):
     )
     @classmethod
     def _bool_none_to_false(cls, v):
-        # Remnawave 2.8.0 может присылать null для булевых полей (напр. verifyPeerCertByName,
-        # когда пиннинг сертификата не настроен) — трактуем None как False, иначе pydantic
-        # роняет валидацию и вместе с ней весь список хостов.
-        return False if v is None else v
+        # Remnawave может присылать null или пустую строку для булевых полей
+        # (напр. verifyPeerCertByName, когда пиннинг сертификата не настроен) —
+        # трактуем None/'' как False, иначе pydantic роняет валидацию и вместе
+        # с ней весь список хостов.
+        if v is None or v == '':
+            return False
+        return v
 
     class Config:
         from_attributes = True
@@ -98,8 +101,8 @@ class HostDetail(HostListItem):
     @field_validator('override_sni_from_address', 'keep_sni_blank', mode='before')
     @classmethod
     def _detail_bool_none_to_false(cls, v):
-        # 2.8.0 может присылать null и для этих булевых полей детального ответа.
-        return False if v is None else v
+        # Remnawave может присылать null и пустую строку для булевых полей детального ответа.
+        return False if v is None or v == '' else v
 
 
 class HostCreate(BaseModel):

--- a/web/backend/tests/test_hosts_api.py
+++ b/web/backend/tests/test_hosts_api.py
@@ -71,6 +71,25 @@ class TestMapHost:
         assert detail.override_sni_from_address is False
         assert detail.keep_sni_blank is False
 
+    def test_empty_string_bools_coerced_to_false(self):
+        """Remnawave может присылать '' в булевых полях (напр. verifyPeerCertByName) —
+        пустая строка приводится к False, иначе валидация падает и роняет список хостов."""
+        from web.backend.schemas.host import HostListItem, HostDetail
+        raw = {
+            "uuid": "h-empty", "remark": "r", "address": "a", "port": 443,
+            "is_disabled": "", "is_hidden": "", "shuffle_host": "",
+            "mihomo_x25519": "", "verify_peer_cert_by_name": "",
+        }
+        item = HostListItem(**raw)
+        assert item.verify_peer_cert_by_name is False
+        assert item.is_disabled is False
+        assert item.is_hidden is False
+        assert item.shuffle_host is False
+        assert item.mihomo_x25519 is False
+        detail = HostDetail(**raw, override_sni_from_address="", keep_sni_blank="")
+        assert detail.override_sni_from_address is False
+        assert detail.keep_sni_blank is False
+
 
 class TestListHosts:
     """GET /api/v2/hosts."""


### PR DESCRIPTION
## Problem

Remnawave returns `verifyPeerCertByName: ""` (empty string) for hosts without cert pinning configured. The `_bool_none_to_false` validator only handled `None`, and pydantic 2.8 refuses to coerce `""` to `bool`.

Result: `GET /api/v2/hosts` returned `500` (`ValidationError`), which took down the entire hosts page in the admin panel.

## Changes

- `web/backend/schemas/host.py`: the boolean field validators (`_bool_none_to_false`, `_detail_bool_none_to_false`) now treat an empty string `""` as `False`, same as `None`.
- `web/backend/tests/test_hosts_api.py`: added regression test `test_empty_string_bools_coerced_to_false`.

## Verification

All 10 `test_hosts_api.py` tests pass.