### PR TITLE
feat(backend): add public API to trigger panel sync

### DIFF
--- a/docs/en/reference/api-endpoints.md
+++ b/docs/en/reference/api-endpoints.md
@@ -116,6 +116,7 @@ Bulk endpoints use the dedicated bulk rate limit bucket (`API_V3_RATE_BULK_PER_M
 | `/nodes/{uuid}/enable` | POST | `nodes:write` | Enable node |
 | `/nodes/{uuid}/disable` | POST | `nodes:write` | Disable node |
 | `/nodes/{uuid}/restart` | POST | `nodes:write` | Restart node |
+| `/nodes/sync` | POST | `nodes:write` | Sync the node list from the panel |
 | `/nodes/{uuid}/agent-token/generate` | POST | `nodes:token` | Generate (rotate) the node's agent token |
 | `/nodes/{uuid}/agent-token/revoke` | POST | `nodes:token` | Revoke the node's agent token |
 

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -91,7 +91,7 @@ scope required by the endpoint.
 | `users:write` | Create/update/enable/disable/reset-traffic | `POST /users`, `POST /users/{uuid}/enable`, `POST /users/{uuid}/reset-traffic` |
 | `users:delete` | Delete a single user | `DELETE /users/{uuid}` |
 | `nodes:read` | Read node list/detail | `GET /nodes`, `GET /nodes/{uuid}` |
-| `nodes:write` | Enable/disable/restart a node | `POST /nodes/{uuid}/restart` |
+| `nodes:write` | Enable/disable/restart a node, sync the node list from the panel | `POST /nodes/{uuid}/restart` |
 | `nodes:token` | Generate/revoke a node's agent token | `POST /nodes/{uuid}/agent-token/generate` |
 | `hosts:read` | Read hosts | `GET /hosts`, `GET /hosts/{uuid}` |
 | `stats:read` | Global statistics | `GET /stats` |

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -95,6 +95,7 @@
 | `/nodes/{uuid}/enable` | POST | `nodes:write` | включить |
 | `/nodes/{uuid}/disable` | POST | `nodes:write` | отключить |
 | `/nodes/{uuid}/restart` | POST | `nodes:write` | перезапустить |
+| `/nodes/sync` | POST | `nodes:write` | синхронизировать список нод с панелью |
 | `/nodes/{uuid}/agent-token/generate` | POST | `nodes:token` | сгенерировать (перевыпустить) токен агента |
 | `/nodes/{uuid}/agent-token/revoke` | POST | `nodes:token` | отозвать токен агента |
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -79,7 +79,7 @@ const res = await fetch("https://admin.example.com/api/v3/users", {
 | `users:write` | создавать, менять, включать, сбрасывать трафик | `POST /users`, `POST /users/{uuid}/enable` |
 | `users:delete` | удалять пользователя | `DELETE /users/{uuid}` |
 | `nodes:read` | читать ноды | `GET /nodes`, `GET /nodes/{uuid}` |
-| `nodes:write` | включать, отключать, перезапускать ноду | `POST /nodes/{uuid}/restart` |
+| `nodes:write` | включать, отключать, перезапускать ноду, синхронизировать список нод с панелью | `POST /nodes/{uuid}/restart` |
 | `nodes:token` | генерировать и отзывать токен агента ноды | `POST /nodes/{uuid}/agent-token/generate` |
 | `hosts:read` | читать хосты | `GET /hosts` |
 | `stats:read` | общая статистика | `GET /stats` |

--- a/web/backend/api/v3/public.py
+++ b/web/backend/api/v3/public.py
@@ -73,6 +73,11 @@ class NodeTokenResult(_PublicBase):
     message: str = ""
 
 
+class SyncResult(BaseModel):
+    success: bool
+    synced: int
+
+
 class HostPublic(_PublicBase):
     uuid: str
     remark: Optional[str] = None
@@ -425,6 +430,26 @@ async def restart_node(
         return SuccessResult(success=True, message="Node restarted")
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/nodes/sync", response_model=SyncResult)
+async def sync_nodes(
+    api_key: ApiKeyUser = Depends(require_scope("nodes:write")),
+):
+    """Sync all nodes from the Remnawave panel into the local DB.
+
+    Fetches every node from the panel, upserts them locally, and removes
+    local nodes no longer present on the panel. Same sync the admin UI's
+    Settings -> Sync page triggers manually.
+    """
+    from shared.sync import sync_service
+
+    try:
+        synced = await sync_service.sync_nodes()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    return SyncResult(success=True, synced=synced)
 
 
 @router.post("/nodes/{uuid}/agent-token/generate", response_model=NodeTokenResult)

--- a/web/backend/tests/test_public_api_v3_node_sync.py
+++ b/web/backend/tests/test_public_api_v3_node_sync.py
@@ -1,0 +1,74 @@
+"""Tests for /api/v3/nodes/sync (scope nodes:write)."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from web.backend.core.config import get_web_settings
+from web.backend.main import create_app
+
+
+VALID_KEY = {"id": 1, "name": "test-key", "scopes": ["nodes:write"]}
+READ_ONLY_KEY = {"id": 2, "name": "limited-key", "scopes": ["nodes:read"]}
+
+
+@pytest.fixture()
+def v3_app(monkeypatch):
+    """FastAPI app with the public API v3 enabled."""
+    monkeypatch.setenv("EXTERNAL_API_ENABLED", "true")
+    get_web_settings.cache_clear()
+    _app = create_app()
+    yield _app
+    _app.dependency_overrides.clear()
+    get_web_settings.cache_clear()
+
+
+@pytest_asyncio.fixture()
+async def v3_client(v3_app):
+    transport = ASGITransport(app=v3_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestSyncNodesV3:
+    """POST /api/v3/nodes/sync."""
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self, v3_client):
+        resp = await v3_client.post("/api/v3/nodes/sync")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    @patch("web.backend.core.api_key_auth.validate_api_key", new_callable=AsyncMock, return_value=READ_ONLY_KEY)
+    async def test_missing_scope(self, _mock_validate, v3_client):
+        resp = await v3_client.post("/api/v3/nodes/sync", headers={"X-API-Key": "rwa_test"})
+        assert resp.status_code == 403
+        assert "nodes:write" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    @patch("shared.sync.sync_service.sync_nodes", new_callable=AsyncMock, return_value=7)
+    @patch("web.backend.core.api_key_auth.validate_api_key", new_callable=AsyncMock, return_value=VALID_KEY)
+    async def test_sync_success(self, _mock_validate, mock_sync, v3_client):
+        resp = await v3_client.post("/api/v3/nodes/sync", headers={"X-API-Key": "rwa_test"})
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "synced": 7}
+        mock_sync.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("shared.sync.sync_service.sync_nodes", new_callable=AsyncMock, side_effect=RuntimeError("panel unreachable"))
+    @patch("web.backend.core.api_key_auth.validate_api_key", new_callable=AsyncMock, return_value=VALID_KEY)
+    async def test_panel_error_returns_502(self, _mock_validate, _mock_sync, v3_client):
+        resp = await v3_client.post("/api/v3/nodes/sync", headers={"X-API-Key": "rwa_test"})
+        assert resp.status_code == 502
+        assert "panel unreachable" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    @patch("shared.sync.sync_service.sync_nodes", new_callable=AsyncMock, return_value=0)
+    @patch("web.backend.core.api_key_auth.validate_api_key", new_callable=AsyncMock, return_value=VALID_KEY)
+    async def test_db_disconnected_returns_zero_synced(self, _mock_validate, _mock_sync, v3_client):
+        """sync_nodes() itself no-ops to 0 when db_service isn't connected — not our
+        concern to special-case, just pass the count through."""
+        resp = await v3_client.post("/api/v3/nodes/sync", headers={"X-API-Key": "rwa_test"})
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "synced": 0}


### PR DESCRIPTION
Please note what this MR was written using Claude, since i don't have sufficient knowledge to write this myself
This is an indirect addition to #272 

### Summary
Adds `POST /api/v3/nodes/sync` under the existing `nodes:write` scope.

Wraps the existing `sync_service.sync_nodes()` — the same full-nodes sync the admin UI's Settings → Sync page already triggers manually. Fetches every node from the panel, upserts locally, and removes local nodes no longer present on the panel.

No new scope, no new sync logic — just exposes an existing internal capability over the public API.

### Testing

New `web/backend/tests/test_public_api_v3_node_sync.py` (401/403/200/502 cases). Full backend suite passes, no regressions.